### PR TITLE
Option to create dummy sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,17 @@
-
 <p align="center">
 <img src="https://github.com/homebridge/branding/raw/master/logos/homebridge-wordmark-logo-vertical.png" width="150">
 </p>
 
-
 # Homebridge Volumio Speakers
 
 Add your Volumio zones to Apple Homekit. This platform plugin uses the [SmartSpeaker](https://developers.homebridge.io/#/service/SmartSpeaker) service to automatically create accessories from
-all your Volumio zones that show up as real speakers in Homekit. 
+all your Volumio zones that show up as real speakers in Homekit.
 
 ## Functionality
 
 **You must have iOS 13.4 or later.**
 
-All your zones (non-private) will show up in Homekit (after you add them one by one, see instructions below).
+All your zones will show up in Homekit (after you add them one by one, see instructions below).
 
 Currently the `SmartSpeaker` service is extremely limited and it only has the following functionality:
 
@@ -51,21 +49,25 @@ Use the Homebridge Config UI X `Settings` link, or add the `Volumio Speakers` pl
 
 ```json
 {
-    "platforms": [
-        {
-            "platform": "Volumio Speakers",
-            "serverURL": "http://volumio.local"
-        }
-    ]
+  "platforms": [
+    {
+      "platform": "Volumio Speakers",
+      "serverURL": "http://volumio.local",
+      "serverPort": 3000,
+      "makeDummySensor": false
+    }
+  ]
 }
 ```
 
 You can use the following options in your homebridge config:
 
-Variable | Optional/Required | Description
--------- | ----------------- | -----------
-`platform` | **required** | Must be `Volumio Speakers`.
-`serverURL` | **required** | The url of one of your Volumio servers. Other servers/zones will be auto discovered from there.
+| Variable          | Optional/Required | Description                                                                                                                                                                                                |
+| ----------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `platform`        | **required**      | Must be `Volumio Speakers`.                                                                                                                                                                                |
+| `serverURL`       | **required**      | The url of one of your Volumio servers. Other servers/zones will be auto discovered from there.                                                                                                            |
+| `serverPort`      | **optional**      | The websocket port of one of your Volumio servers (Default 3000). You should only need this if you're doing some advanced networking                                                                       |
+| `makeDummySensor` | **optional**      | Creates another sensor type accessory for each discovered Volumio Zone. The status of the sensor is true while media is playing. This is used for building automations triggered by Volumio playing music. |
 
 ## How to use
 
@@ -74,10 +76,10 @@ Once configured, restart Homebridge and keep an eye on the logs.
 Then in the Homebridge logs, you should see all your zones get accessories created for them.
 
 The final step is to add each output accessory to Homekit, manually. To do this:
- 
+
 1. In Homekit on iOS go to "Add accessory"
 2. Then hit "I Don't Have a Code or Cannot Scan"
 3. You should see all your outputs listed on "Nearby Accessories"
 4. Hit the first one, then hit "Add anyway", then enter the code provided by Homebridge (check your Homebridge logs).
 5. On the final screen, just hit "Done". You can now add the speaker to one of your rooms by long pressing it and using the edit cog.
-6. Repeat for each zone.
+6. Repeat for each zone and/or sensor.

--- a/config.schema.json
+++ b/config.schema.json
@@ -16,10 +16,17 @@
       },
       "serverPort": {
         "title": "Websocket Port",
+        "description": "Default port for Volumio websocket is 3000. You should only need to change this if you're doing some advanced networking",
         "type": "number",
         "placeholder": 3000,
         "minimum": 0,
         "maximum": 65353
+      },
+      "makeDummySensor": {
+        "title": "Dummy Sensors",
+        "description": "Creates another sensor type accessory for each discovered Volumio Zone. The status of the sensor is true while media is playing. This is used for building automations triggered by Volumio playing music",
+        "type": "boolean",
+        "default": false
       }
     }
   },
@@ -37,9 +44,8 @@
       "expandable": true,
       "expanded": false,
       "items": [
-        {
-          "key": "serverPort"
-        }
+        "makeDummySensor",
+        "serverPort"
       ]
     }
   ]

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -25,7 +25,7 @@ interface ZoneState {
 }
 
 /**
- * Volumio Speakers Platform Accessory.
+ * Volumio Speakers Platform Accessory
  */
 export class PluginPlatformAccessory {
   private service: Service;
@@ -153,17 +153,17 @@ export class PluginPlatformAccessory {
   }
 
   /**
- * Get the targetMediaState.
- */
+   * Get the targetMediaState
+   */
   getTargetMediaState(callback: CharacteristicGetCallback): void {
     this.log.debug('GET TargetMediaState:', this.zoneState.status);
     callback(undefined, this.zoneState.status);
   }
 
   /**
- * Set the targetMediaState.
- * Toggle play/pause
- */
+   * Set the targetMediaState
+   * Toggle play/pause
+   */
   setTargetMediaState(value: CharacteristicValue, callback: CharacteristicSetCallback): void {
     this.log.debug('SET TargetMediaState:', value);
 
@@ -188,15 +188,15 @@ export class PluginPlatformAccessory {
   }
 
   /**
- * Get the Volume.
- */
+   * Get the Volume
+   */
   getVolume(callback: CharacteristicGetCallback): void {
     this.log.debug('GET Volume:', this.zoneState.volume);
     callback(undefined, this.zoneState.volume);
   }
 
   /**
-   * Set the Volume.
+   * Set the Volume
    */
   setVolume(value: CharacteristicValue, callback: CharacteristicSetCallback): void {
     this.log.debug('SET Volume:', value);
@@ -209,15 +209,15 @@ export class PluginPlatformAccessory {
   }
 
   /**
- * Get the Mute state.
- */
+   * Get the Mute state
+   */
   getMute(callback: CharacteristicGetCallback): void {
     this.log.debug('GET Muted:', this.zoneState.muted);
     callback(undefined, this.zoneState.muted);
   }
 
   /**
-   * Set the Volume.
+   * Set the Volume
    */
   setMute(value: CharacteristicValue, callback: CharacteristicSetCallback): void {
     this.log.debug('SET Mute:', value);
@@ -242,8 +242,8 @@ export class PluginPlatformAccessory {
   }
 
   /**
-  * Map VolumioAPI's stream property to a bool. Annoyingly, the value is either a bool or a string
-  */
+   * Map VolumioAPI's stream property to a bool. Annoyingly, the value is either a bool or a string
+   */
   convertVolumioStreamValueToBool(value: string | boolean | undefined): boolean {
     let convertedBool = false;
     if (typeof value === 'boolean') {
@@ -256,8 +256,8 @@ export class PluginPlatformAccessory {
   }
 
   /**
-  * Map VolumioAPIStatus -> CharacteristicValue
-  */
+   * Map VolumioAPIStatus -> CharacteristicValue
+   */
   convertVolumioStatusToCharacteristicValue(status: VolumioAPIStatus): CharacteristicValue {
     // These are the state strings returned by Volumio
     switch (status) {
@@ -272,8 +272,8 @@ export class PluginPlatformAccessory {
   }
   
   /**
-  * Map CharacteristicValue -> VolumioAPIStatus
-  */
+   * Map CharacteristicValue -> VolumioAPIStatus
+   */
   convertCharacteristicValueToVolumioStatus(status: CharacteristicValue): VolumioAPIStatus {
     // These are the state strings returned by Volumio
     switch (status) {

--- a/src/sensorAccessory.ts
+++ b/src/sensorAccessory.ts
@@ -1,0 +1,127 @@
+import {
+  Service,
+  PlatformAccessory,
+  CharacteristicGetCallback,
+  CharacteristicEventTypes,
+  Logger,
+} from 'homebridge';
+import { PluginPlatform } from './platform';
+import {
+  DefaultWebsocketPort,
+  socketManagement,
+  VolumioAPIState,
+  VolumioAPIStatus,
+} from './utils';
+import io from 'socket.io-client';
+
+/**
+ * Volumio Speakers Sensor Accessory
+ */
+export class PluginSensorAccessory {
+  private service: Service;
+  private socket: SocketIOClient.Socket;
+  private sensorState: boolean;
+  private log: Logger;
+
+  constructor(
+    private readonly platform: PluginPlatform,
+    public readonly accessory: PlatformAccessory,
+  ) {
+    const logPrefix = `${this.accessory.displayName}:`;
+    this.log = <Logger>{
+      info: (...args) => this.platform.log.info(logPrefix, ...args),
+      debug: (...args) => this.platform.log.debug(logPrefix, ...args),
+      warn: (...args) => this.platform.log.warn(logPrefix, ...args),
+      error: (...args) => this.platform.log.error(logPrefix, ...args),
+    };
+
+    this.sensorState = false;
+
+    // Set up socket connection
+    const host = this.accessory.context.host;
+    this.socket = io.connect(`${host}:${this.platform.config.serverPort || DefaultWebsocketPort}`);
+    socketManagement(this.socket, this.log);
+
+    // Get initial state and listen for updates
+    this.socket.on('pushState', this.updateZoneState.bind(this));
+    this.socket.emit('getState', '');
+
+
+    this.accessory.getService(this.platform.Service.AccessoryInformation)!
+      .setCharacteristic(this.platform.Characteristic.Manufacturer, 'Volumio')
+      .setCharacteristic(this.platform.Characteristic.Model, 'Zone Dummy Sensor')
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, this.accessory.UUID);
+
+    this.service =
+        this.accessory.getService(this.platform.Service.ContactSensor)
+        || this.accessory.addService(this.platform.Service.ContactSensor);
+
+    // Allows name to show when adding speaker.
+    this.service.setCharacteristic(this.platform.Characteristic.ConfiguredName, this.accessory.displayName);
+
+    // Event handlers for CurrentMediaState and TargetMediaState Characteristics.
+    this.service.getCharacteristic(this.platform.Characteristic.ContactSensorState)
+      .on(CharacteristicEventTypes.GET, this.getContactSensorState.bind(this));
+  }
+
+  /**
+   * Update zone host if network condition changes
+   */
+  public updateHost(host: string): void {
+    this.log.info('Updating host IP to:', host);
+    this.accessory.context.host = host;
+    
+    // Do socket disconnect/reconnect
+    this.socket.off('pushState');
+    this.socket.disconnect();
+
+    this.socket = io.connect(`${host}:${this.platform.config.serverPort || DefaultWebsocketPort}`);
+    socketManagement(this.socket, this.log);
+
+    // Get initial state and listen for updates
+    this.socket.on('pushState', this.updateZoneState.bind(this));
+    this.socket.emit('getState', '');
+  }
+
+  /**
+   * Update display name shown in Homekit
+   */
+  public updateDisplayName(name: string): void {
+    this.log.info('Updating display name to:', name);
+    this.accessory.displayName = name;
+    this.service.getCharacteristic(this.platform.Characteristic.Name).updateValue(this.accessory.displayName);
+  }
+
+  /**
+   * Update local and Homebridge data from socket publish
+   */
+  updateZoneState(data: VolumioAPIState): void {
+    this.log.debug('Recieved socket publish:', JSON.stringify(data));
+    const convertedData = this.convertVolumioAPIStateToSensorState(data);
+    
+    this.log.debug('Converted Data:', JSON.stringify(convertedData));
+    this.log.debug('Current state:', JSON.stringify(this.sensorState));
+    
+    // Only update if returned data is different than current stored state
+    if (convertedData !== this.sensorState) {
+      this.log.debug('Updating sensor state');
+      this.sensorState = convertedData;
+      this.service.getCharacteristic(this.platform.Characteristic.ContactSensorState).updateValue(this.sensorState);
+    }
+  }
+
+  /**
+   * Get the targetMediaState
+   */
+  getContactSensorState(callback: CharacteristicGetCallback): void {
+    this.log.debug('GET ContactSensorState:', this.sensorState);
+    callback(undefined, this.sensorState);
+  }
+
+  /**
+   * Map VolumioAPIStatus to sesnor status bool
+   */
+  convertVolumioAPIStateToSensorState(data: VolumioAPIState): boolean {
+    return data.status === VolumioAPIStatus.PLAY;
+  }
+}


### PR DESCRIPTION
Address feature request #10. When the `makeDummySensor` config setting is `true`, a contact sensor will be created alongside each Volumio zone. The sensor will be `open` while music is playing and `closed` while paused or stopped. This allows you to create automations based on player state.